### PR TITLE
Max buy sell buttons

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -112,6 +112,10 @@ class PlayScreen extends StatelessWidget {
                       gameState.player.inventoryQuantity(sweet.id);
                   final canBuy = gameState.player.cash >= buyPrice;
                   final canSell = ownedQuantity > 0;
+                  final maxBuyQuantity = buyPrice > 0
+                      ? (gameState.player.cash / buyPrice).floor()
+                      : 0;
+                  final canBuyMax = maxBuyQuantity > 0;
 
                   final cardColor = _sweetCardColors[sweet.id];
 
@@ -134,26 +138,65 @@ class PlayScreen extends StatelessWidget {
                           ),
                           Text('You own: $ownedQuantity'),
                           const SizedBox(height: 8),
-                          Row(
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              ElevatedButton(
-                                style: buyButtonStyle,
-                                onPressed: canBuy
-                                    ? () {
-                                        gameActions.buy(sweet.id, 1);
-                                      }
-                                    : null,
-                                child: const Text('Buy 1'),
+                              Wrap(
+                                spacing: 8,
+                                runSpacing: 8,
+                                children: [
+                                  ElevatedButton(
+                                    style: buyButtonStyle,
+                                    onPressed: canBuy
+                                        ? () {
+                                            gameActions.buy(sweet.id, 1);
+                                          }
+                                        : null,
+                                    child: const Text('Buy 1'),
+                                  ),
+                                  ElevatedButton(
+                                    style: buyButtonStyle,
+                                    onPressed: canBuyMax
+                                        ? () {
+                                            gameActions.buy(
+                                              sweet.id,
+                                              maxBuyQuantity,
+                                            );
+                                          }
+                                        : null,
+                                    child: const Text('Buy Max'),
+                                  ),
+                                ],
                               ),
-                              const SizedBox(width: 8),
-                              OutlinedButton(
-                                style: outlinedIntentStyle(_sellAccentColor),
-                                onPressed: canSell
-                                    ? () {
-                                        gameActions.sell(sweet.id, 1);
-                                      }
-                                    : null,
-                                child: const Text('Sell 1'),
+                              const SizedBox(height: 8),
+                              Wrap(
+                                spacing: 8,
+                                runSpacing: 8,
+                                children: [
+                                  OutlinedButton(
+                                    style:
+                                        outlinedIntentStyle(_sellAccentColor),
+                                    onPressed: canSell
+                                        ? () {
+                                            gameActions.sell(sweet.id, 1);
+                                          }
+                                        : null,
+                                    child: const Text('Sell 1'),
+                                  ),
+                                  OutlinedButton(
+                                    style:
+                                        outlinedIntentStyle(_sellAccentColor),
+                                    onPressed: canSell
+                                        ? () {
+                                            gameActions.sell(
+                                              sweet.id,
+                                              ownedQuantity,
+                                            );
+                                          }
+                                        : null,
+                                    child: const Text('Sell All'),
+                                  ),
+                                ],
                               ),
                             ],
                           ),

--- a/test/screens/play_screen_test.dart
+++ b/test/screens/play_screen_test.dart
@@ -48,13 +48,16 @@ void main() {
     expect(find.textContaining('Days left'), findsOneWidget);
   });
 
-  testWidgets('PlayScreen shows sweets from GameData with Buy 1 and Sell 1', (WidgetTester tester) async {
+  testWidgets('PlayScreen shows sweets from GameData with buy and sell actions',
+      (WidgetTester tester) async {
     await tester.pumpWidget(buildTestWidget());
 
     for (final sweet in GameData.sweets) {
       expect(find.text(sweet.name), findsOneWidget);
     }
     expect(find.text('Buy 1'), findsNWidgets(GameData.sweets.length));
+    expect(find.text('Buy Max'), findsNWidgets(GameData.sweets.length));
     expect(find.text('Sell 1'), findsNWidgets(GameData.sweets.length));
+    expect(find.text('Sell All'), findsNWidgets(GameData.sweets.length));
   });
 }


### PR DESCRIPTION
Add "Buy Max" and "Sell All" controls to each sweet card to provide more convenient bulk buying/selling options.

---
<a href="https://cursor.com/background-agent?bcId=bc-198ccf31-ca5e-46ec-80d2-2069dbe80639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-198ccf31-ca5e-46ec-80d2-2069dbe80639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

